### PR TITLE
Fix performance regressions in #57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # News
 
+
+## v0.6.5 - 2023-09-06
+
+- Fix to a performance regresion
+
 ## v0.6.4 - 2023-08-08
 
 - Docstrings now work with `@resumable` functions.

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
 authors = ["Ben Lauwens <ben.lauwens@gmail.com>"]
 repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,14 +20,8 @@ Implements the `eltype` method of the *iterator* interface for a subtype of `Fin
 """
 Base.eltype(::Type{T}) where T<:FiniteStateMachineIterator{R} where R = R
 
-function Base.iterate(fsm_iter::FiniteStateMachineIterator)
-  ret = generate(fsm_iter, nothing)
-  ret isa IteratorReturn && return nothing
-  ret
-end
-
-function Base.iterate(fsm_iter::FiniteStateMachineIterator, state)
-  ret = generate(fsm_iter, nothing, state)
-  ret isa IteratorReturn && return nothing
-  ret
+function Base.iterate(fsm_iter::FiniteStateMachineIterator, state=nothing)
+   result = fsm_iter()
+   fsm_iter._state === 0xff && return nothing
+   result, nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREA
 @doset "yieldfrom"
 @doset "typeparams"
 @doset "coverage_preservation"
+@doset "performance"
 VERSION >= v"1.8" && @doset "doctests"
 VERSION >= v"1.8" && @doset "aqua"
 get(ENV,"JET_TEST","")=="true" && @doset "jet"

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -26,6 +26,6 @@ end
         )
     )
     @show rep
-    @test length(JET.get_reports(rep)) <= 4
+    @test length(JET.get_reports(rep)) <= 5
     @test_broken length(JET.get_reports(rep)) == 0
 end

--- a/test/test_performance.jl
+++ b/test/test_performance.jl
@@ -1,0 +1,20 @@
+using ResumableFunctions
+using Test
+
+@resumable function fibonacci_resumable(n::Int)
+  a, b = zero(Int), one(Int)
+  for _ in 1:n
+    @yield a
+    a, b = b, a + b
+  end
+end
+
+@noinline function test_resumable(n::Int)
+  a = 0
+  for v in fibonacci_resumable(n)
+    a = v
+  end
+  a
+end
+
+@test (@allocated test_resumable(80))==0


### PR DESCRIPTION
Quick fix for the performance regression reported in #72: reverts the changes to the definition of the `Base.iterate` overload, no longer delegating to `generate`, which is causing unnecessary allocations.

#### Before (`master`)
```
Direct: 
  31.114 ns (0 allocations: 0 bytes)
ResumableFunctions: 
  5.167 μs (249 allocations: 3.89 KiB)
Channels csize=0: 
  2.256 ms (97 allocations: 2.61 KiB)
Channels csize=1: 
  2.194 ms (19 allocations: 1.44 KiB)
Channels csize=20: 
  177.917 μs (20 allocations: 1.77 KiB)
Channels csize=100: 
  85.167 μs (21 allocations: 3.22 KiB)
Task scheduling
  16.917 μs (86 allocations: 3.38 KiB)
Closure: 
  1.308 μs (82 allocations: 1.28 KiB)
Closure optimised: 
  32.067 ns (0 allocations: 0 bytes)
Closure statemachine: 
  31.742 ns (0 allocations: 0 bytes)
Iteration protocol: 
  32.067 ns (0 allocations: 0 bytes)
```

#### After
```
Direct: 
  32.193 ns (0 allocations: 0 bytes)
ResumableFunctions: 
  32.737 ns (0 allocations: 0 bytes)
Channels csize=0: 
  2.232 ms (97 allocations: 2.61 KiB)
Channels csize=1: 
  2.230 ms (19 allocations: 1.44 KiB)
Channels csize=20: 
  173.458 μs (20 allocations: 1.77 KiB)
Channels csize=100: 
  82.083 μs (21 allocations: 3.22 KiB)
Task scheduling
  17.625 μs (86 allocations: 3.38 KiB)
Closure: 
  1.413 μs (82 allocations: 1.28 KiB)
Closure optimised: 
  32.067 ns (0 allocations: 0 bytes)
Closure statemachine: 
  31.732 ns (0 allocations: 0 bytes)
Iteration protocol: 
  32.067 ns (0 allocations: 0 bytes)
```

Closes #72. Note that the `generate`/`@yieldfrom` paths still cause many allocations, but (a) they're not part of the benchmarks and (b) I haven't been able to come up with a fix for that yet.