### PR TITLE
run inference in generated function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # News
 
+## v0.6.6 - TBD
+
+- Improved performance on Julia nightly by more precise inference of slot types
 
 ## v0.6.5 - 2023-09-06
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
 authors = ["Ben Lauwens <ben.lauwens@gmail.com>"]
 repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -74,7 +74,7 @@ macro resumable(expr::Expr)
   else
     fsmi_name = :($type_name{$(params...)})
   end
-  fwd_args, fwd_kwargs = forward_args(func_def)
+  fwd_args, fwd_kwargs = forward_args(call_def)
   call_def[:body] = quote
     fsmi = ResumableFunctions.typed_fsmi($fsmi_name, $inferfn, $(fwd_args...), $(fwd_kwargs...))
     $((arg !== Symbol("_") ? :(fsmi.$arg = $arg) : nothing for arg in args)...)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -46,6 +46,7 @@ macro resumable(expr::Expr)
   slot_T_sub = [:($k <: $v) for (k, v) in zip(slot_T, values(slots))]
   struct_name = :($type_name{$(func_def[:whereparams]...), $(slot_T_sub...)} <: ResumableFunctions.FiniteStateMachineIterator{$rtype})
   constr_def[:whereparams] = (func_def[:whereparams]..., slot_T_sub...)
+  # if there are no where or slot type parameters, we need to use the bare type
   if isempty(params) && isempty(slot_T)
     constr_def[:name] = :($type_name)
   else
@@ -59,6 +60,8 @@ macro resumable(expr::Expr)
     fsmi._state = 0x00
     fsmi
   end
+  # the bare/fallback version of the constructor supplies default slot type parameters
+  # we only need to define this if there there are actually slot defaults to be filled
   if !isempty(slot_T)
     bareconstr_def = copy(constr_def)
     if isempty(params)

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -254,7 +254,7 @@ function transform_yield(expr)
   _is_yield(expr) || return expr
   ret = length(expr.args) > 2 ? expr.args[3:end] : [nothing]
   quote
-    $(ret...)
+    Base.inferencebarrier($(ret...))
   end
 end
 

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -100,7 +100,7 @@ end
 """
 Function that replaces a variable `x` in an expression by `_fsmi.x` where `x` is a known slot.
 """
-function transform_slots(expr, symbols::Base.KeySet{Symbol, Dict{Symbol,Any}})
+function transform_slots(expr, symbols)
   expr isa Expr || return expr
   expr.head === :let && return transform_slots_let(expr, symbols)
   for i in 1:length(expr.args)
@@ -114,7 +114,7 @@ end
 """
 Function that handles `let` block
 """
-function transform_slots_let(expr::Expr, symbols::Base.KeySet{Symbol, Dict{Symbol,Any}})
+function transform_slots_let(expr::Expr, symbols)
   @capture(expr, let vars_; body_ end)
   locals = Set{Symbol}()
   (isa(vars, Expr) && vars.head==:(=))  || error("@resumable currently supports only single variable declarations in let blocks, i.e. only let blocks exactly of the form `let i=j; ...; end`. If you need multiple variables, please submit an issue on the issue tracker and consider contributing a patch.")

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -247,8 +247,10 @@ end
 """
 Function that replaces a `@yield ret` or `@yield` statement with
 ```julia
-  return ret
+  Base.inferencebarrier(ret)
 ```
+This version is used for inference only.
+It makes sure that `val = @yield ret` is inferred as `Any` rather than `typeof(ret)`.
 """
 function transform_yield(expr)
   _is_yield(expr) || return expr

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -139,9 +139,8 @@ function code_typed_by_type(@nospecialize(tt::Type);
     tt = Base.to_tuple_type(tt)
     # look up the method
     match, valid_worlds = Core.Compiler.findsup(tt, Core.Compiler.InternalMethodTable(world))
-    meth = Base.func_for_method_checked(match.method, tt, match.sparams)
     # run inference, normally not allowed in generated functions
-    frame = Core.Compiler.typeinf_frame(interp, meth, match.spec_types, match.sparams, optimize)
+    frame = Core.Compiler.typeinf_frame(interp, match.method, match.spec_types, match.sparams, optimize)
     frame === nothing && error("inference failed")
     valid_worlds = Core.Compiler.intersect(valid_worlds, frame.valid_worlds)
     return frame.linfo, frame.src, valid_worlds

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -199,11 +199,6 @@ if VERSION >= v"1.10.0-DEV.873"
 else
   # runtime fallback function
   function typed_fsmi(fsmi::Type{T}, fargs...)::T where T
-    slots = fieldtypes(T)[2:end]
-    if isempty(slots)
-      return T()
-    else
-      return T{slots...}()
-    end
+    return T()
   end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -142,6 +142,7 @@ function code_typed_by_type(@nospecialize(tt::Type);
     meth = Base.func_for_method_checked(match.method, tt, match.sparams)
     # run inference, normally not allowed in generated functions
     frame = Core.Compiler.typeinf_frame(interp, meth, match.spec_types, match.sparams, optimize)
+    valid_worlds = Core.Compiler.intersect(valid_worlds, frame.valid_worlds)
     frame === nothing && error("inference failed")
     return frame.linfo, frame.src, valid_worlds
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,12 @@ function get_args(func_def::Dict)
   arg_list, kwarg_list, arg_dict
 end
 
+"""
+Takes a function definition and returns the expressions needed to forward the arguments to an inner function.
+For example `function foo(a, ::Int, c...; x, y=1, z...)` will
+1. moodify the function to `gensym()` nameless arguments
+2. return `(:a, gensym(), :(c...)), (:x, :y, :(z...)))`
+"""
 function forward_args(func_def)
   args = []
   map!(func_def[:args], func_def[:args]) do arg
@@ -94,16 +100,6 @@ Function removing the `exc` symbol of a `catch exc` statement of a list of slots
 """
 function remove_catch_exc(expr, slots::Dict{Symbol, Any})
   @capture(expr, (try body__ catch exc_; handling__ end) | (try body__ catch exc_; handling__ finally always__ end)) && delete!(slots, exc)
-  expr
-end
-
-"""
-Function changing the type of a slot `arg` of a `arg = @yield ret` or `arg = @yield` statement to `Any`.
-"""
-function make_arg_any(expr, slots::Dict{Symbol, Any})
-  @capture(expr, arg_ = ex_) || return expr
-  _is_yield(ex) || return expr
-  slots[arg] = Any
   expr
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -198,7 +198,7 @@ if VERSION >= v"1.10.0-DEV.873"
 else
   # runtime fallback function
   function typed_fsmi(fsmi::Type{T}, fargs...)::T where T
-    slots = fieldtypes(fsmi)[2:end]
+    slots = fieldtypes(T)[2:end]
     if isempty(slots)
       return T()
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -175,8 +175,21 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype:
     return ci
 end
 
-# low level generated function for caller world age
-@eval function typed_fsmi(fsmi, fargs...)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, fsmi_generator))
+# JuliaLang/julia#48611: world age is exposed to generated functions, and should be used
+if fieldcount(Core.GeneratedFunctionStub) == 3
+  # low level generated function for caller world age
+  @eval function typed_fsmi(fsmi, fargs...)
+      $(Expr(:meta, :generated_only))
+      $(Expr(:meta, :generated, fsmi_generator))
+  end
+else
+  # runtime fallback function
+  function typed_fsmi(fsmi, fargs...)
+    slots = fill(Any, length(fieldnames(fsmi))-1)
+    if isempty(slots)
+      return fsmi()
+    else
+      return fsmi{slots...}()
+    end
+  end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -152,7 +152,7 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype:
     # get typed code of the inference function evaluated in get_slots
     # but this time with concrete argument types
     tt = Base.to_tuple_type(fargtypes)
-    mi, ci, (; min_world, max_world) = try
+    mi, ci, valid_worlds = try
       code_typed_by_type(tt; world, optimize=false)
     catch err # inference failed, return generic type
       Core.println(err)
@@ -164,6 +164,8 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype:
         return stub(world, source, :(return $T{$(slots...)}()))
       end
     end
+    min_world = valid_worlds.min_world
+    max_world = valid_worlds.max_world
     # extract slot types
     cislots = Dict{Symbol, Any}()
     for (name, type) in collect(zip(ci.slotnames, ci.slottypes))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -142,8 +142,8 @@ function code_typed_by_type(@nospecialize(tt::Type);
     meth = Base.func_for_method_checked(match.method, tt, match.sparams)
     # run inference, normally not allowed in generated functions
     frame = Core.Compiler.typeinf_frame(interp, meth, match.spec_types, match.sparams, optimize)
-    valid_worlds = Core.Compiler.intersect(valid_worlds, frame.valid_worlds)
     frame === nothing && error("inference failed")
+    valid_worlds = Core.Compiler.intersect(valid_worlds, frame.valid_worlds)
     return frame.linfo, frame.src, valid_worlds
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,7 +159,11 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype,
     cislots = Dict(zip(ci.slotnames, ci.slottypes))
     slots = [get(cislots, arg, Any) for arg in _tfieldnames(fsmitype)[2:end]]
     stub = Core.GeneratedFunctionStub(identity, Core.svec(:pass, :fsmi, :fargs), Core.svec())
-    exprs = stub(world, source, :(return fsmi{$(slots...)}()))
+    if isempty(slots)
+      exprs = stub(world, source, :(return fsmi()))
+    else
+      exprs = stub(world, source, :(return fsmi{$(slots...)}()))
+    end
     # lower codeinfo to pass world age and invalidation edges
     ci = ccall(:jl_expand_and_resolve, Any, (Any, Any, Any), exprs, passtype.name.module, Core.svec())
     ci.min_world = min_world

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -197,7 +197,7 @@ if VERSION >= v"1.10.0-DEV.873"
       $(Expr(:meta, :generated, fsmi_generator))
   end
 else
-  # runtime fallback function
+  # runtime fallback function that uses the fallback constructor with generic slot types
   function typed_fsmi(fsmi::Type{T}, fargs...)::T where T
     return T()
   end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -26,6 +26,6 @@ end
         )
     )
     @show rep
-    @test length(JET.get_reports(rep)) <= 5
+    @test length(JET.get_reports(rep)) <= 8
     @test_broken length(JET.get_reports(rep)) == 0
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -22,7 +22,7 @@ end
     rep = report_package("ResumableFunctions";
         report_pass=MayThrowIsOk(),
         ignored_modules=(
-
+            Core.Compiler,
         )
     )
     @show rep

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -216,3 +216,14 @@ end
 @testset "test_docstring" begin
 @test (@doc fwithdoc) == (@doc gwithdoc)
 end
+
+@resumable function test_unstable(a::Int)
+  for i in 1:a
+    a = "number $i"
+    @yield a
+  end
+end
+
+@testset "test_unstable" begin
+  @test collect(test_unstable(3)) == ["number 1", "number 2", "number 3"]
+end

--- a/test/test_performance.jl
+++ b/test/test_performance.jl
@@ -18,3 +18,19 @@ end
 end
 
 @test (@allocated test_resumable(80))==0
+
+
+@resumable function cumsum(iter)
+  acc = zero(eltype(iter))
+  for i in iter
+    acc += i
+    @yield acc
+  end
+end
+
+# versions that support generating inferred code
+if VERSION >= v"1.10.0-DEV.873"
+  cs = cumsum(1:1000)
+  @allocated cs() # shake out the compilation overhead
+  @test (@allocated cs())==0
+end


### PR DESCRIPTION
Previously this package ran inference on the code as written, which only worked well with concrete type annotations on the arguments. Due to how the Julia compiler works, generic type variables are not propagated during inference. This leads to bad performance for many common use cases, because the fsm struct would contain mostly `Any` fields.

This PR intends to run inference in a generated function. This allows us to see the concrete types of the method as called, and correctly infer the types of local variables.

However, the Julia compiler does not want you to call inference from a generated method, which makes this PR tricky.
A non-exhaustive list of things we need to verify and fix about this PR:

- backedges/invalidations
- keyword arguments
- type parameters
- multiple methods