### PR TITLE
Support for self-referencing functionals

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
       - uses: cjdoris/julia-downgrade-compat-action@v1
         with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra
+          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra,Logging
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # News
 
-## v0.6.8 - 2024-02-07
+## v0.6.9 - 2024-02
+
+- Self-referencing functionals (callable structs) are now supported as resumable functions, e.g. `@resumable (f::A)() return f.property end`. 
+
+## v0.6.8 - 2024-02-11
 
 - Redeploy the improved performance from v0.6.6 without the issues that caused them to be reverted in v0.6.7. The issue stemmed from lack of support for recursive resumable functions in the v0.6.6 improvements.
 - Significant additions to the CI and testing of the package to avoid such issues in the future.
+
 ## v0.6.7 - 2024-01-02
 
 - Fix stack overflow errors by reverting the changes introduced in v0.6.6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # News
 
-## v0.6.9 - 2024-02
+## v0.6.9 - 2024-02-13
 
-- Self-referencing functionals (callable structs) are now supported as resumable functions, e.g. `@resumable (f::A)() return f.property end`. 
+- Self-referencing functionals (callable structs) are now supported as resumable functions, e.g. `@resumable (f::A)() @yield f.property end`.
 
 ## v0.6.8 - 2024-02-11
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
 version = "0.6.9"
 
 [deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
+Logging = "1"
 MacroTools = "0.5.6"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
 authors = ["Ben Lauwens <ben.lauwens@gmail.com>"]
 repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/ResumableFunctions.jl
+++ b/src/ResumableFunctions.jl
@@ -6,7 +6,13 @@ module ResumableFunctions
   using MacroTools
   using MacroTools: combinedef, combinearg, flatten, postwalk
 
-  export @resumable, @yield, @nosave, @yieldfrom 
+  export @resumable, @yield, @nosave, @yieldfrom
+
+  function __init__()
+    STDERR_HAS_COLOR[] = get(stderr, :color, false)
+  end
+
+  include("safe_logging.jl")
 
   include("types.jl")
   include("transforms.jl")

--- a/src/safe_logging.jl
+++ b/src/safe_logging.jl
@@ -1,0 +1,31 @@
+# safe logging, copied from GPUCompiler
+
+using Logging
+
+const STDERR_HAS_COLOR = Ref{Bool}(false)
+
+# Prevent invalidation when packages define custom loggers
+# Using invoke in combination with @nospecialize eliminates backedges to these methods
+function _invoked_min_enabled_level(@nospecialize(logger))
+    return invoke(Logging.min_enabled_level, Tuple{typeof(logger)}, logger)::LogLevel
+end
+
+# define safe loggers for use in generated functions (where task switches are not allowed)
+for level in [:debug, :info, :warn, :error]
+    @eval begin
+        macro $(Symbol("safe_$level"))(ex...)
+            macrocall = :(@placeholder $(ex...))
+            # NOTE: `@placeholder` in order to avoid hard-coding @__LINE__ etc
+            macrocall.args[1] = Symbol($"@$level")
+            quote
+                old_logger = global_logger()
+                io = IOContext(Core.stderr, :color=>STDERR_HAS_COLOR[])
+                min_level = _invoked_min_enabled_level(old_logger)
+                global_logger(Logging.ConsoleLogger(io, min_level))
+                ret = $(esc(macrocall))
+                global_logger(old_logger)
+                ret
+            end
+        end
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -150,8 +150,8 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype:
     mi, ci, valid_worlds = try
       code_typed_by_type(tt; world, optimize=false)
     catch err # inference failed, return generic type
-      Core.println("inference of a @resumable function failed -- a slower fallback will be used and everything will still work, however please consider reporting this to the developers of ResumableFunctions.jl so that we can debug and increase performance")
-      Core.println(err)
+      @safe_warn "Inference of a @resumable function failed -- a slower fallback will be used and everything will still work, however please consider reporting this to the developers of ResumableFunctions.jl so that we can debug and increase performance"
+      @safe_warn "The error was $err"
       slots = fieldtypes(T)[2:end]
       stub = Core.GeneratedFunctionStub(identity, Core.svec(:pass, :fsmi, :fargs), Core.svec())
       if isempty(slots)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -150,6 +150,7 @@ function fsmi_generator(world::UInt, source::LineNumberNode, passtype, fsmitype:
     mi, ci, valid_worlds = try
       code_typed_by_type(tt; world, optimize=false)
     catch err # inference failed, return generic type
+      Core.println("inference of a @resumable function failed -- a slower fallback will be used and everything will still work, however please consider reporting this to the developers of ResumableFunctions.jl so that we can debug and increase performance")
       Core.println(err)
       slots = fieldtypes(T)[2:end]
       stub = Core.GeneratedFunctionStub(identity, Core.svec(:pass, :fsmi, :fargs), Core.svec())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREA
 @doset "typeparams"
 @doset "repeated_variable"
 @doset "inference_recursive_calls"
+@doset "selfreferencing_functional"
 @doset "coverage_preservation"
 @doset "performance"
 VERSION >= v"1.8" && @doset "doctests"

--- a/test/test_selfreferencing_functional.jl
+++ b/test/test_selfreferencing_functional.jl
@@ -1,0 +1,12 @@
+using Test
+using ResumableFunctions
+
+struct A
+    a::Int
+end;
+@resumable function (fa::A)(b::Int)
+    @yield b+fa.a
+end
+
+@test collect(A(1)(2)) == [3]
+@test_broken collect(A(1)(2)) isa Vector{Int}


### PR DESCRIPTION
This builds upon #88 -- it is one single commit more. It will look much simpler after #88 is merged.

Fixes #77 

I.e after this is merged we can do things like

```
struct A
    a::Int
end
@resumable function (f::A)()
    @yield f.a
end
@assert collect(A(1)()) == [1]
```