### PR TITLE
feat: Add `length` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## ???
+
+- Add `length` support by allowing `@resumable length=ex function [...]`
+
 ## v0.6.10 - 2024-05-11
 
 - Adjust to an internal changes in Julia 1.12 (see julia#54341).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # News
 
-## ???
+## v0.6.11 - 2024-09-08
 
 - Add `length` support by allowing `@resumable length=ex function [...]`
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,9 @@ uuid = "c5292f4c-5179-55e1-98c5-05642aab7184"
 keywords = ["generator", "semi-coroutine", "resumable function"]
 license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
-authors = ["Ben Lauwens <ben.lauwens@gmail.com>"]
-repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
-version = "0.6.10"
+authors = ["Ben Lauwens and volunteer maintainers"]
+repo = "https://github.com/JuliaDynamics/ResumableFunctions.jl.git"
+version = "0.6.11"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ end
 for fib in fibonacci(10)
   println(fib)
 end
+
+# Example with specifies the length
+using ResumableFunctions
+
+@resumable length=n^2 function fibonacci(n::Int) :: Int
+  a = 0
+  b = 1
+  for i in 1:n^2
+    @yield a
+    a, b = b, a+b
+  end
+end
+
+for fib in fibonacci(5)
+  println(fib)
+end
 ```
 
 ## Benchmarks

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -227,3 +227,19 @@ end
 @testset "test_unstable" begin
   @test collect(test_unstable(3)) == ["number 1", "number 2", "number 3"]
 end
+
+# test length
+
+@testset "test_length" begin
+  @resumable length=n^2*m^2 function test_length(n, m)
+    for i in 1:n^2
+      for j in 1:m^2
+        @yield i + j
+      end
+    end
+  end
+
+  @test length(test_length(10, 20)) === 10^2 * 20^2
+  @test length(collect(test_length(10, 20))) === 10^2 * 20^2
+  @test Base.IteratorSize(typeof(test_length(1, 1))) == Base.HasLength()
+end


### PR DESCRIPTION
Adds a keyword argument `length=ex` to allow for specifying the
length of the iterator.

Closes #41
