### PR TITLE
ExplicitImports compliance and general cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 examples/.ipynb_checkpoints
 docs/build
 Manifest.toml
+Manifest-v*.toml
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.0.5 - unreleased
+
+- Some general cleanup of the code, and adding ExplicitImports.jl tests for long term maintainability.
+
 ## v1.0.4 - 2025-08-25
 
 - Support comprehensions with conditionals, e.g., `@resumable function f1(); [i for i in 1:10 if i<5]; end` which previously led to "Illegal expression" errors.

--- a/src/ResumableFunctions.jl
+++ b/src/ResumableFunctions.jl
@@ -3,15 +3,16 @@ Main module for ResumableFunctions.jl – C# style generators a.k.a. semi-corout
 """
 module ResumableFunctions
 
-  using MacroTools
-  using MacroTools: combinedef, combinearg, flatten, postwalk
+using MacroTools: striplines, @capture, flatten, postwalk, inexpr
+using MacroTools: combinedef, splitdef, combinearg, splitarg
 
-  export @resumable, @yield, @nosave, @yieldfrom
+export @resumable, @yield, @nosave, @yieldfrom
 
-  include("safe_logging.jl")
+include("safe_logging.jl")
 
-  include("types.jl")
-  include("transforms.jl")
-  include("utils.jl")
-  include("macro.jl")
+include("types.jl")
+include("transforms.jl")
+include("utils.jl")
+include("macro.jl")
+
 end

--- a/src/safe_logging.jl
+++ b/src/safe_logging.jl
@@ -1,6 +1,6 @@
 # safe logging, copied from GPUCompiler
 
-using Logging
+using Logging: Logging, @debug, @info, @warn, @error, LogLevel, global_logger
 
 # Prevent invalidation when packages define custom loggers
 # Using invoke in combination with @nospecialize eliminates backedges to these methods

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,3 +40,4 @@ println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREA
 VERSION >= v"1.8" && @doset "doctests"
 VERSION >= v"1.8" && @doset "aqua"
 get(ENV,"JET_TEST","")=="true" && @doset "jet"
+@doset "explicitimports"

--- a/test/test_explicitimports.jl
+++ b/test/test_explicitimports.jl
@@ -1,0 +1,25 @@
+using ExplicitImports
+using ResumableFunctions
+using Test
+
+@testset "ExplicitImports tests" begin
+    @test check_no_implicit_imports(ResumableFunctions) === nothing
+    @test check_no_stale_explicit_imports(ResumableFunctions) === nothing
+    @test check_all_explicit_imports_via_owners(ResumableFunctions) === nothing
+
+    # MacroTools.jl has been inconsistent in marking documented functions as public (or exporting them), 
+    # gradually doing different ones over different versions. So work around that.
+    nonpublic_ignore = ()
+    macrotools_module = @eval(ResumableFunctions,
+        only(filter((k, v)::Pair -> k.name == "MacroTools", Base.loaded_modules)).second)
+    if pkgversion(macrotools_module) < v"0.5.10"
+        nonpublic_ignore = (:flatten, :postwalk, :striplines, :combinedef, :combinearg)
+    elseif pkgversion(macrotools_module) < v"0.5.17"
+        nonpublic_ignore = (:flatten, :postwalk, :striplines)
+    end
+    @test check_all_explicit_imports_are_public(ResumableFunctions; ignore=nonpublic_ignore) === nothing
+
+    @test check_all_qualified_accesses_via_owners(ResumableFunctions;
+        skip=(Base => Core, Core.Compiler => Base)) === nothing
+end
+


### PR DESCRIPTION
Did some mild general cleanup while going through the code, and also made it compliant with ExplicitImport.jl's tests for improved maintainability. 

#### A couple of explanations 

* [Change to `new_s`](https://github.com/JuliaDynamics/ResumableFunctions.jl/compare/master...digital-carver:dcarv/explimp?expand=1#diff-47c27891e951c8cd946b850dc2df31082624afdf57446c21cb6992f5f4b74aa2L282-R286) is so that we don't wrongly re-use the argument name `new` for a variable that's unrelated and has a different type. 

* [`new_stack` and `let` block changes](https://github.com/JuliaDynamics/ResumableFunctions.jl/compare/master...digital-carver:dcarv/explimp?expand=1#diff-47c27891e951c8cd946b850dc2df31082624afdf57446c21cb6992f5f4b74aa2L484-R549): `new_stack` is never used for `:let` blocks, and the function returns at the end of the `let` if condition, so assigning it there does nothing, hence removed. Similarly, since `let` has already been handled and returned, checking for that alongside the check for `while` is needless and that part of the conditiion will never evaluate to true. 

