### PR TITLE
fix to allow positional vararg eg. `fn(a...; kw)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.5 - unreleased
 
 - Some general cleanup of the code, and adding ExplicitImports.jl tests for long term maintainability.
+- Fix the error when there is a positional vararg eg. `fn(a...; kw)` (#135)
 
 ## v1.0.4 - 2025-08-25
 

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -80,6 +80,18 @@ end
 @test collect(test_varargs(1, 2, 3)) == [1, 2, 3]
 end
 
+@resumable function test_varargs_kwargs(a...; k...)
+  @yield a
+  @yield k
+end
+
+@testset "test_varargs_kwargs" begin
+  it = test_varargs_kwargs(1, 2, x=3, y=4)
+  res = collect(it)
+  @test res[1] == (1, 2)
+  @test Dict(res[2]) == Dict(:x => 3, :y => 4)
+end
+
 @testset "test_let" begin
   @resumable function test_let()
     for u in [[(1,2),(3,4)], [(5,6),(7,8)]]


### PR DESCRIPTION
Since the function construction in `get_slots` is only used to get slot names, always pretend the final positional arg is non-splat. This prevents the error from trying to construct `fn(a..., kw)`, and otherwise has no impact since the slot names themselves remain the same.

Resolves #135 