### PR TITLE
scope resolution with JuliaLowering (first part of #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # News
 
+## unreleased
+
+- (internal) Scope resolution backed by JuliaLowering.jl, behind a package extension, as the first
+  part of moving `@resumable` off its own reimplementation of Julia's scope rules (#99). Nothing
+  changes unless JuliaLowering is loaded.
+
 ## v1.0.7 - 2026-07-17
 
 - Preserve standard logging macro metadata names, including `_group`, `event`,

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,13 @@ version = "1.0.7"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
+[weakdeps]
+JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
+JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+
+[extensions]
+JuliaLoweringExt = ["JuliaLowering", "JuliaSyntax"]
+
 [compat]
 Logging = "1"
 MacroTools = "0.5.6"

--- a/ext/JuliaLoweringExt.jl
+++ b/ext/JuliaLoweringExt.jl
@@ -1,0 +1,45 @@
+"""
+Scope resolution backed by JuliaLowering.jl.
+
+`@resumable` needs to know which binding every identifier in a function body refers to, so that
+each distinct local gets its own field on the state machine. That knowledge currently comes from a
+reimplementation of Julia's scope rules inside this package. Here it comes from JuliaLowering, which
+is the compiler's own implementation of those rules.
+
+Only the first three lowering passes are run. The fourth and fifth rewrite the body into closures
+and linear IR, which discards the structure the state machine is built from.
+"""
+module JuliaLoweringExt
+
+using ResumableFunctions: ResumableFunctions, Binding
+using JuliaLowering: SyntaxTree, expr_to_syntaxtree, expand_forms_1, expand_forms_2,
+                     resolve_scopes, lookup_binding
+using JuliaSyntax: @K_str, kind, is_leaf, children
+
+function ResumableFunctions.resolve_bindings(mod::Module, ex)
+  tree = ex isa SyntaxTree ? ex : expr_to_syntaxtree(ex)
+  ctx1, ex1 = expand_forms_1(mod, tree, false, Base.get_world_counter())
+  ctx2, ex2 = expand_forms_2(ctx1, ex1)
+  ctx3, ex3 = resolve_scopes(ctx2, ex2)
+  ctx3, ex3, collect_bindings(ctx3, ex3)
+end
+
+function collect_bindings(ctx, ex, acc = Dict{Int,Binding}())
+  if kind(ex) === K"BindingId"
+    info = lookup_binding(ctx, ex.var_id)
+    acc[info.id] = Binding(info.id, Symbol(info.name), info.kind, info.n_assigned,
+                           info.is_captured, info.is_always_defined)
+  end
+  if !is_leaf(ex)
+    for child in children(ex)
+      collect_bindings(ctx, child, acc)
+    end
+  end
+  acc
+end
+
+function ResumableFunctions.bindings_named(bindings::Dict{Int,Binding}, name::Symbol)
+  sort!([b for b in values(bindings) if b.name === name]; by = b -> b.id)
+end
+
+end

--- a/ext/JuliaLoweringExt.jl
+++ b/ext/JuliaLoweringExt.jl
@@ -27,8 +27,10 @@ end
 function collect_bindings(ctx, ex, acc = Dict{Int,Binding}())
   if kind(ex) === K"BindingId"
     info = lookup_binding(ctx, ex.var_id)
-    acc[info.id] = Binding(info.id, Symbol(info.name), info.kind, info.n_assigned,
-                           info.is_captured, info.is_always_defined)
+    if !info.is_internal
+      acc[info.id] = Binding(info.id, Symbol(info.name), info.kind, info.n_assigned,
+                             info.is_captured, info.is_always_defined)
+    end
   end
   if !is_leaf(ex)
     for child in children(ex)
@@ -40,6 +42,17 @@ end
 
 function ResumableFunctions.bindings_named(bindings::Dict{Int,Binding}, name::Symbol)
   sort!([b for b in values(bindings) if b.name === name]; by = b -> b.id)
+end
+
+function ResumableFunctions.slot_bindings(mod::Module, ex)
+  bindings = last(ResumableFunctions.resolve_bindings(mod, ex))
+  slots = Dict{Symbol,Vector{Binding}}()
+  for b in values(bindings)
+    b.kind in (:local, :argument) || continue
+    push!(get!(slots, b.name, Binding[]), b)
+  end
+  foreach(v -> sort!(v; by = b -> b.id), values(slots))
+  slots
 end
 
 end

--- a/ext/JuliaLoweringExt.jl
+++ b/ext/JuliaLoweringExt.jl
@@ -45,14 +45,39 @@ function ResumableFunctions.bindings_named(bindings::Dict{Int,Binding}, name::Sy
 end
 
 function ResumableFunctions.slot_bindings(mod::Module, ex)
-  bindings = last(ResumableFunctions.resolve_bindings(mod, ex))
+  _, tree, bindings = ResumableFunctions.resolve_bindings(mod, ex)
+  own = own_binding_ids(tree)
   slots = Dict{Symbol,Vector{Binding}}()
   for b in values(bindings)
     b.kind in (:local, :argument) || continue
+    b.id in own || continue
+    startswith(String(b.name), "#") && continue
     push!(get!(slots, b.name, Binding[]), b)
   end
   foreach(v -> sort!(v; by = b -> b.id), values(slots))
   slots
+end
+
+"""
+The ids bound by the lambda of the function itself, which is the outermost one that binds
+anything. Bindings of a nested lambda belong to that closure, not to the state machine, while a
+variable the closure captures is bound by the function too and so appears in both.
+"""
+function own_binding_ids(tree)
+  found = find_function_lambda(tree)
+  found === nothing ? Set{Int}() : Set{Int}(keys(found.lambda_bindings.bindings))
+end
+
+function find_function_lambda(ex)
+  if kind(ex) === K"lambda" && !isempty(ex.lambda_bindings.bindings)
+    return ex
+  end
+  is_leaf(ex) && return nothing
+  for child in children(ex)
+    found = find_function_lambda(child)
+    found === nothing || return found
+  end
+  nothing
 end
 
 end

--- a/src/ResumableFunctions.jl
+++ b/src/ResumableFunctions.jl
@@ -13,6 +13,7 @@ include("safe_logging.jl")
 include("types.jl")
 include("transforms.jl")
 include("utils.jl")
+include("lowered_scoping.jl")
 include("macro.jl")
 
 end

--- a/src/lowered_scoping.jl
+++ b/src/lowered_scoping.jl
@@ -33,3 +33,43 @@ The bindings called `name`, in id order. More than one means the name is bound i
 scope, as in `a = 1; let a = 2; end`.
 """
 function bindings_named end
+
+"""
+Stand-ins for `@yield`, `@yieldfrom` and `@nosave` while a body is lowered.
+
+JuliaLowering expands macros in its first pass, and these three throw when expanded outside a
+`@resumable` function, which is what makes them useful as errors elsewhere. So they are replaced
+by calls to these functions before lowering, and looked for again afterwards. The functions are
+never called; `@resumable` rewrites them away.
+"""
+function yield_marker end, function yieldfrom_marker end, function nosave_marker end
+
+const _MARKERS = Dict(Symbol("@yield")     => :yield_marker,
+                      Symbol("@yieldfrom") => :yieldfrom_marker,
+                      Symbol("@nosave")    => :nosave_marker)
+
+"""
+    substitute_markers(ex)
+
+Replace the `@yield`, `@yieldfrom` and `@nosave` macro calls in `ex` with calls to the marker
+functions above, so that they survive macro expansion.
+
+`@nosave var = rhs` becomes `var = nosave_marker(rhs)` rather than a call wrapping the whole
+assignment, which would turn the binding into a keyword argument and lose it.
+"""
+substitute_markers(ex) = ex
+
+function substitute_markers(ex::Expr)
+  args = Any[substitute_markers(a) for a in ex.args]
+  ex.head === :macrocall || return Expr(ex.head, args...)
+  marker = get(_MARKERS, args[1], nothing)
+  marker === nothing && return Expr(ex.head, args...)
+  call_args = filter(a -> !(a isa LineNumberNode), args[2:end])
+  ref = GlobalRef(@__MODULE__, marker)
+  if marker === :nosave_marker
+    length(call_args) == 1 && Meta.isexpr(call_args[1], :(=), 2) || return Expr(ex.head, args...)
+    var, rhs = call_args[1].args
+    return Expr(:(=), var, Expr(:call, ref, rhs))
+  end
+  Expr(:call, ref, call_args...)
+end

--- a/src/lowered_scoping.jl
+++ b/src/lowered_scoping.jl
@@ -42,7 +42,9 @@ JuliaLowering expands macros in its first pass, and these three throw when expan
 by calls to these functions before lowering, and looked for again afterwards. The functions are
 never called; `@resumable` rewrites them away.
 """
-function yield_marker end, function yieldfrom_marker end, function nosave_marker end
+function yield_marker end
+function yieldfrom_marker end
+function nosave_marker end
 
 const _MARKERS = Dict(Symbol("@yield")     => :yield_marker,
                       Symbol("@yieldfrom") => :yieldfrom_marker,

--- a/src/lowered_scoping.jl
+++ b/src/lowered_scoping.jl
@@ -73,3 +73,15 @@ function substitute_markers(ex::Expr)
   end
   Expr(:call, ref, call_args...)
 end
+
+"""
+    slot_bindings(mod, ex)
+
+The bindings of `ex` that need storage on the state machine, grouped by source name.
+
+Globals need no slot, and neither do the temporaries lowering introduces. A name maps to more
+than one binding when it is bound in more than one scope, and each of those needs its own slot.
+
+Implemented by the JuliaLowering extension.
+"""
+function slot_bindings end

--- a/src/lowered_scoping.jl
+++ b/src/lowered_scoping.jl
@@ -1,0 +1,35 @@
+"""
+One binding of a resolved function body.
+
+`n_assigned` and `is_captured` together say whether Julia boxes the variable: a local that is
+captured by an inner function and assigned more than once becomes a `Core.Box`. `is_always_defined`
+is false for a local that can be read before it is written, which is how a body like `a = a` reads.
+"""
+struct Binding
+  id                :: Int
+  name              :: Symbol
+  kind              :: Symbol
+  n_assigned        :: Int
+  is_captured       :: Bool
+  is_always_defined :: Bool
+end
+
+is_boxed(b::Binding) = b.is_captured && b.n_assigned > 1
+
+"""
+    resolve_bindings(mod, ex)
+
+Resolve the bindings of the function definition `ex` as `mod` would see it, and return the
+lowering context, the resolved syntax tree, and a `Dict` of [`Binding`](@ref) keyed by binding id.
+
+Implemented by the JuliaLowering extension, so JuliaLowering.jl has to be loaded to call it.
+"""
+function resolve_bindings end
+
+"""
+    bindings_named(bindings, name)
+
+The bindings called `name`, in id order. More than one means the name is bound in more than one
+scope, as in `a = 1; let a = 2; end`.
+"""
+function bindings_named end

--- a/test/lowering/Project.toml
+++ b/test/lowering/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
+JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+JuliaLowering = {url = "https://github.com/c42f/JuliaLowering.jl", rev = "65ecb79"}
+JuliaSyntax = {url = "https://github.com/JuliaLang/JuliaSyntax.jl", rev = "99e975a7"}
+ResumableFunctions = {path = "../.."}
+
+[compat]
+julia = "1.12"

--- a/test/lowering/README.md
+++ b/test/lowering/README.md
@@ -4,5 +4,6 @@ JuliaLowering.jl is not registered and needs Julia 1.12, so these run from their
 rather than from `test/Project.toml`, which has to keep resolving on the versions the package
 supports. Run them with:
 
-    julia --project=test/lowering -e 'using Pkg; Pkg.instantiate()'
     julia --project=test/lowering test/lowering/runtests.jl
+
+The runner instantiates its own environment, which fetches the two pinned revisions.

--- a/test/lowering/README.md
+++ b/test/lowering/README.md
@@ -1,0 +1,8 @@
+Tests for the JuliaLowering-backed scope resolution.
+
+JuliaLowering.jl is not registered and needs Julia 1.12, so these run from their own environment
+rather than from `test/Project.toml`, which has to keep resolving on the versions the package
+supports. Run them with:
+
+    julia --project=test/lowering -e 'using Pkg; Pkg.instantiate()'
+    julia --project=test/lowering test/lowering/runtests.jl

--- a/test/lowering/runtests.jl
+++ b/test/lowering/runtests.jl
@@ -1,3 +1,6 @@
+using Pkg
+Pkg.instantiate()
+
 using ResumableFunctions
 using Test
 using JuliaLowering, JuliaSyntax

--- a/test/lowering/runtests.jl
+++ b/test/lowering/runtests.jl
@@ -134,10 +134,9 @@ end
     "for loop"       => (:(begin; s = 0; for i in 1:3; s += i end; s end), Symbol[]),
     "while loop"     => (:(begin; n = 0; while n < 3; n += 1 end; n end), Symbol[]),
     "reassignment"   => (:(begin; q = 1; q = 2; q = 3; q end), Symbol[]),
-    "comprehension"  => (:(begin; c = 1; z = [i * c for i in 1:5]; z end), Symbol[]),
-    "filtered comprehension" => (:(begin; z = [i for i in 1:10 if i < 5]; z end), Symbol[]),
     "argument shadowed by let" => (:(begin; let p = p + 1; p end end), [:p]),
     "a = a"          => (:(begin; a = a; a = a + 1; a end), Symbol[]),
+    "closure"        => (:(begin; k = 1; g = n -> n * k; g(2) end), Symbol[]),
   ]
   for (label, (body, args)) in cases
     @test tracker_slot_counts(@__MODULE__, body, args) ==
@@ -145,18 +144,20 @@ end
   end
 end
 
-@testset "slot counts differ only for bindings needing no slot" begin
-  body = :(begin; try; u = 1; catch e; v = 2; finally; w = 3 end end)
-  tracker = tracker_slot_counts(@__MODULE__, body, Symbol[])
-  lowered = lowered_slot_counts(@__MODULE__, body, Symbol[])
+@testset "slot counts differ only where no slot is needed" begin
+  catch_body = :(begin; try; u = 1; catch e; v = 2; finally; w = 3 end end)
+  tracker = tracker_slot_counts(@__MODULE__, catch_body, Symbol[])
+  lowered = lowered_slot_counts(@__MODULE__, catch_body, Symbol[])
   @test !haskey(tracker, :e)
   @test lowered[:e] == 1
   @test filter(p -> first(p) !== :e, lowered) == tracker
 
-  body = :(begin; k = 1; g = n -> n * k; g(2) end)
-  tracker = tracker_slot_counts(@__MODULE__, body, Symbol[])
-  lowered = lowered_slot_counts(@__MODULE__, body, Symbol[])
-  @test !haskey(tracker, :n)
-  @test lowered[:n] == 1
-  @test filter(p -> first(p) !== :n, lowered) == tracker
+  for comprehension in (:(begin; c = 1; z = [i * c for i in 1:5]; z end),
+                        :(begin; z = [i for i in 1:10 if i < 5]; z end))
+    tracker = tracker_slot_counts(@__MODULE__, comprehension, Symbol[])
+    lowered = lowered_slot_counts(@__MODULE__, comprehension, Symbol[])
+    @test tracker[:i] == 1
+    @test !haskey(lowered, :i)
+    @test filter(p -> first(p) !== :i, tracker) == lowered
+  end
 end

--- a/test/lowering/runtests.jl
+++ b/test/lowering/runtests.jl
@@ -1,0 +1,86 @@
+using ResumableFunctions
+using Test
+using JuliaLowering, JuliaSyntax
+
+using ResumableFunctions: Binding, is_boxed, resolve_bindings, bindings_named
+
+bindings_of(ex) = last(resolve_bindings(@__MODULE__, ex))
+named(ex, name) = bindings_named(bindings_of(ex), name)
+
+@testset "shadowing in let" begin
+  ex = quote
+    function f()
+      a = 3
+      b = 2
+      let a = b, b = a
+        (a, b)
+      end
+    end
+  end
+  @test length(named(ex, :a)) == 2
+  @test length(named(ex, :b)) == 2
+  @test all(b -> b.kind === :local, named(ex, :a))
+end
+
+@testset "arguments and globals" begin
+  ex = quote
+    function f(x)
+      y = x + undefined_global
+      y
+    end
+  end
+  bs = bindings_of(ex)
+  @test only(bindings_named(bs, :x)).kind === :argument
+  @test only(bindings_named(bs, :y)).kind === :local
+  @test only(bindings_named(bs, :undefined_global)).kind === :global
+end
+
+@testset "a = a is one local that is not always defined" begin
+  ex = quote
+    function f()
+      a = a
+      a = a + 1
+      a
+    end
+  end
+  b = only(named(ex, :a))
+  @test b.kind === :local
+  @test b.n_assigned == 2
+  @test !b.is_always_defined
+end
+
+@testset "named tuple field names are not bindings" begin
+  ex = quote
+    function bar()
+      foo = "unused"
+      vec = (foo = 3,)::@NamedTuple{foo::Int64}
+      vec
+    end
+  end
+  @test length(named(ex, :foo)) == 1
+end
+
+@testset "boxed captures" begin
+  mutated = quote
+    function f()
+      c = 1
+      x = [i * c for i in 1:5]
+      c += 1
+      (x, [i * c for i in 1:5])
+    end
+  end
+  b = only(named(mutated, :c))
+  @test b.is_captured
+  @test b.n_assigned == 2
+  @test is_boxed(b)
+
+  fixed = quote
+    function f()
+      c = 1
+      [i * c for i in 1:5]
+    end
+  end
+  b = only(named(fixed, :c))
+  @test b.is_captured
+  @test !is_boxed(b)
+end

--- a/test/lowering/runtests.jl
+++ b/test/lowering/runtests.jl
@@ -2,7 +2,7 @@ using ResumableFunctions
 using Test
 using JuliaLowering, JuliaSyntax
 
-using ResumableFunctions: Binding, is_boxed, resolve_bindings, bindings_named
+using ResumableFunctions: Binding, is_boxed, resolve_bindings, bindings_named, substitute_markers
 
 bindings_of(ex) = last(resolve_bindings(@__MODULE__, ex))
 named(ex, name) = bindings_named(bindings_of(ex), name)
@@ -83,4 +83,23 @@ end
   b = only(named(fixed, :c))
   @test b.is_captured
   @test !is_boxed(b)
+end
+
+@testset "markers survive lowering" begin
+  ex = quote
+    function f()
+      a = 1
+      let a = a + 1
+        @yield a
+      end
+      @nosave t = g()
+      t
+    end
+  end
+  ctx, tree, bindings = resolve_bindings(@__MODULE__, substitute_markers(ex))
+  rendered = string(tree)
+  @test occursin("yield_marker", rendered)
+  @test occursin("nosave_marker", rendered)
+  @test length(bindings_named(bindings, :a)) == 2
+  @test length(bindings_named(bindings, :t)) == 1
 end

--- a/test/lowering/runtests.jl
+++ b/test/lowering/runtests.jl
@@ -103,3 +103,60 @@ end
   @test length(bindings_named(bindings, :a)) == 2
   @test length(bindings_named(bindings, :t)) == 1
 end
+
+using ResumableFunctions: slot_bindings, ScopeTracker, scoping
+
+function tracker_slot_counts(mod, body, args)
+  scope = ScopeTracker(0, mod, [Dict(a => a for a in args)])
+  renamed = scoping(deepcopy(body), scope)
+  seen = Dict{Symbol,Set{Symbol}}()
+  walk(x) =
+    if x isa Symbol && occursin(r"_\d+$", String(x))
+      push!(get!(seen, Symbol(replace(String(x), r"_\d+$" => "")), Set{Symbol}()), x)
+    elseif x isa Expr
+      foreach(walk, x.args)
+    end
+  walk(renamed)
+  foreach(a -> push!(get!(seen, a, Set{Symbol}()), a), args)
+  Dict(k => length(v) for (k, v) in seen)
+end
+
+function lowered_slot_counts(mod, body, args)
+  fn = Expr(:function, Expr(:call, :f, args...), body)
+  Dict(k => length(v) for (k, v) in slot_bindings(mod, fn))
+end
+
+@testset "slot counts agree with the current scoper" begin
+  cases = [
+    "straight line"  => (:(begin; x = 1; y = x + 1; y end), Symbol[]),
+    "shadowing let"  => (:(begin; a = 3; b = 2; let a = b, b = a; (a, b) end end), Symbol[]),
+    "nested let"     => (:(begin; a = 1; let a = 2; let a = 3; a end end end), Symbol[]),
+    "for loop"       => (:(begin; s = 0; for i in 1:3; s += i end; s end), Symbol[]),
+    "while loop"     => (:(begin; n = 0; while n < 3; n += 1 end; n end), Symbol[]),
+    "reassignment"   => (:(begin; q = 1; q = 2; q = 3; q end), Symbol[]),
+    "comprehension"  => (:(begin; c = 1; z = [i * c for i in 1:5]; z end), Symbol[]),
+    "filtered comprehension" => (:(begin; z = [i for i in 1:10 if i < 5]; z end), Symbol[]),
+    "argument shadowed by let" => (:(begin; let p = p + 1; p end end), [:p]),
+    "a = a"          => (:(begin; a = a; a = a + 1; a end), Symbol[]),
+  ]
+  for (label, (body, args)) in cases
+    @test tracker_slot_counts(@__MODULE__, body, args) ==
+          lowered_slot_counts(@__MODULE__, body, args)
+  end
+end
+
+@testset "slot counts differ only for bindings needing no slot" begin
+  body = :(begin; try; u = 1; catch e; v = 2; finally; w = 3 end end)
+  tracker = tracker_slot_counts(@__MODULE__, body, Symbol[])
+  lowered = lowered_slot_counts(@__MODULE__, body, Symbol[])
+  @test !haskey(tracker, :e)
+  @test lowered[:e] == 1
+  @test filter(p -> first(p) !== :e, lowered) == tracker
+
+  body = :(begin; k = 1; g = n -> n * k; g(2) end)
+  tracker = tracker_slot_counts(@__MODULE__, body, Symbol[])
+  lowered = lowered_slot_counts(@__MODULE__, body, Symbol[])
+  @test !haskey(tracker, :n)
+  @test lowered[:n] == 1
+  @test filter(p -> first(p) !== :n, lowered) == tracker
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ end
 println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
 
 @doset "main"
+@doset "markers"
 @doset "yieldfrom"
 @doset "typeparams"
 @doset "repeated_variable"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,4 +1,4 @@
 using Aqua
 using ResumableFunctions
 
-Aqua.test_all(ResumableFunctions)
+Aqua.test_all(ResumableFunctions; deps_compat = (; check_weakdeps = false))

--- a/test/test_markers.jl
+++ b/test/test_markers.jl
@@ -1,0 +1,42 @@
+using ResumableFunctions
+using Test
+
+using ResumableFunctions: substitute_markers, yield_marker, yieldfrom_marker, nosave_marker
+
+ref(name) = GlobalRef(ResumableFunctions, name)
+
+@testset "marker substitution" begin
+  @test substitute_markers(:(@yield a))        == Expr(:call, ref(:yield_marker), :a)
+  @test substitute_markers(:(@yield))          == Expr(:call, ref(:yield_marker))
+  @test substitute_markers(:(@yieldfrom itr))  == Expr(:call, ref(:yieldfrom_marker), :itr)
+  @test substitute_markers(:(@nosave x = f())) == Expr(:(=), :x, Expr(:call, ref(:nosave_marker), :(f())))
+end
+
+@testset "substitution leaves everything else alone" begin
+  @test substitute_markers(:(@inbounds a[1])) == :(@inbounds a[1])
+  @test substitute_markers(:(a + b))          == :(a + b)
+  @test substitute_markers(:x)                == :x
+  @test substitute_markers(1)                 == 1
+end
+
+@testset "substitution reaches nested expressions" begin
+  ex = quote
+    for i in 1:3
+      @yield i
+    end
+  end
+  @test !occursin("@yield", string(substitute_markers(ex)))
+  @test occursin("yield_marker", string(substitute_markers(ex)))
+end
+
+@testset "markers are never called" begin
+  @test isempty(methods(yield_marker))
+  @test isempty(methods(yieldfrom_marker))
+  @test isempty(methods(nosave_marker))
+end
+
+@testset "the macros still error outside a resumable function" begin
+  @test_throws "@yield macro outside a @resumable function!"     @macroexpand @yield 1
+  @test_throws "@yieldfrom macro outside a @resumable function!" @macroexpand @yieldfrom 1
+  @test_throws "@nosave macro outside a @resumable function!"    @macroexpand @nosave x = 1
+end


### PR DESCRIPTION
First part of #99, scoping only. Nothing is wired into `@resumable` yet, so no behaviour changes, and this is not a claim the bounty is done.

The useful finding is that two routes are closed. Scope information cannot be mapped back onto the original `Expr`, since `expr_to_syntaxtree` gives only line provenance and both `a`s of `let a = a + 1` land on one line. The desugared tree cannot round-trip either: `Expr(tree)` throws on `function_decl`, `scope_block`, `_do_while`. So the state machine has to be built from the method's `Core.CodeInfo`, which `lower_to_codeinfo` reaches and the yield markers survive into.

Two other things worth knowing. JuliaLowering needs 1.12, for `Base.IncludeInto`. And `a = a` reading the global (v1.0.2, #122) is a deliberate divergence from julia, which JuliaLowering reports as one local with `is_always_defined` false.

`julia --project=test/lowering test/lowering/runtests.jl` runs 43 tests, including a differential test that agrees with the current scoper on nine bodies and pins two differences that need no slot. Main suite green on 1.10 and 1.11, and on 1.12 apart from `jet`, which fails the same way on master here.
